### PR TITLE
 - Added UIButton+RUTextSize.

### DIFF
--- a/ResplendentUtilities/Code/ResplendentUtilities/Category/NSString/NSString+RUTextSize.h
+++ b/ResplendentUtilities/Code/ResplendentUtilities/Category/NSString/NSString+RUTextSize.h
@@ -14,6 +14,6 @@
 
 @interface NSString (RUTextSize)
 
-- (CGSize)textSizeWithBoundingWidth:(CGFloat)boundingWidth attributes:(NSDictionary *)attributes;
+- (CGSize)textSizeWithBoundingWidth:(CGFloat)boundingWidth attributes:(NSDictionary *)attributes NS_AVAILABLE_IOS(7_0);
 
 @end

--- a/ResplendentUtilities/Code/ResplendentUtilities/Category/NSString/NSString+RUTextSize.m
+++ b/ResplendentUtilities/Code/ResplendentUtilities/Category/NSString/NSString+RUTextSize.m
@@ -16,6 +16,12 @@
 
 - (CGSize)textSizeWithBoundingWidth:(CGFloat)boundingWidth attributes:(NSDictionary *)attributes
 {
+	if ([self respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)] == false)
+	{
+		NSAssert(false, @"should only be able to call this when boundingRectWithSize:options:attributes:context: is available");
+		return CGSizeZero;
+	}
+
 	CGSize boundingSize = (CGSize){.width = boundingWidth,.height = 0};
 	NSStringDrawingOptions options = (NSStringDrawingUsesLineFragmentOrigin | NSStringDrawingTruncatesLastVisibleLine);
 	CGRect textBoundingRect = [self boundingRectWithSize:boundingSize options:options attributes:attributes context:nil];

--- a/ResplendentUtilities/Code/ResplendentUtilities/Category/UIButton+RUTextSize.h
+++ b/ResplendentUtilities/Code/ResplendentUtilities/Category/UIButton+RUTextSize.h
@@ -1,0 +1,20 @@
+//
+//  UIButton+RUTextSize.h
+//  Racer Tracer
+//
+//  Created by Benjamin Maer on 8/18/14.
+//  Copyright (c) 2014 Appy Dragon. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+
+
+
+
+@interface UIButton (RUTextSize)
+
+-(CGSize)ruCurrentTitleTextSizeConstrainedToWidth:(CGFloat)width;
+-(CGSize)ruCurrentTitleTextSize;
+
+@end

--- a/ResplendentUtilities/Code/ResplendentUtilities/Category/UIButton+RUTextSize.m
+++ b/ResplendentUtilities/Code/ResplendentUtilities/Category/UIButton+RUTextSize.m
@@ -1,0 +1,43 @@
+//
+//  UIButton+RUTextSize.m
+//  Racer Tracer
+//
+//  Created by Benjamin Maer on 8/18/14.
+//  Copyright (c) 2014 Appy Dragon. All rights reserved.
+//
+
+#import "UIButton+RUTextSize.h"
+#import "RUAttributesDictionaryBuilder.h"
+#import "NSString+RUTextSize.h"
+
+
+
+
+
+@implementation UIButton (RUTextSize)
+
+-(CGSize)ruCurrentTitleTextSizeConstrainedToWidth:(CGFloat)width
+{
+	NSString* currentTitle = self.currentTitle;
+	if (([currentTitle respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]) &&
+		([currentTitle respondsToSelector:@selector(textSizeWithBoundingWidth:attributes:)]))
+	{
+		RUAttributesDictionaryBuilder* attributesDictionaryBuilder = [RUAttributesDictionaryBuilder new];
+		[attributesDictionaryBuilder absorbPropertiesFromButton:self];
+		return [currentTitle textSizeWithBoundingWidth:width attributes:[attributesDictionaryBuilder createAttributesDictionary]];
+	}
+	else
+	{
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+		return [currentTitle sizeWithFont:self.titleLabel.font constrainedToSize:CGSizeMake(width, CGFLOAT_MAX) lineBreakMode:self.titleLabel.lineBreakMode];
+#pragma clang diagnostic pop
+	}
+}
+
+-(CGSize)ruCurrentTitleTextSize
+{
+	return [self ruCurrentTitleTextSizeConstrainedToWidth:CGFLOAT_MAX];
+}
+
+@end

--- a/ResplendentUtilities/Code/ResplendentUtilities/Category/UILabel/UILabel+RUTextSize.m
+++ b/ResplendentUtilities/Code/ResplendentUtilities/Category/UILabel/UILabel+RUTextSize.m
@@ -18,7 +18,8 @@
 
 -(CGSize)ruTextSizeConstrainedToWidth:(CGFloat)width
 {
-	if ([self.text respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)])
+	if (([self.text respondsToSelector:@selector(boundingRectWithSize:options:attributes:context:)]) &&
+		([self.text respondsToSelector:@selector(textSizeWithBoundingWidth:attributes:)]))
 	{
 		RUAttributesDictionaryBuilder* attributesDictionaryBuilder = [RUAttributesDictionaryBuilder new];
 		[attributesDictionaryBuilder absorbPropertiesFromLabel:self];

--- a/ResplendentUtilities/Code/ResplendentUtilities/Objects/RUAttributesDictionaryBuilder.h
+++ b/ResplendentUtilities/Code/ResplendentUtilities/Objects/RUAttributesDictionaryBuilder.h
@@ -18,6 +18,7 @@
 @property (nonatomic, assign) NSLineBreakMode lineBreakMode;
 
 -(void)absorbPropertiesFromLabel:(UILabel*)label;
+-(void)absorbPropertiesFromButton:(UIButton*)button;
 
 -(NSDictionary*)createAttributesDictionary;
 

--- a/ResplendentUtilities/Code/ResplendentUtilities/Objects/RUAttributesDictionaryBuilder.m
+++ b/ResplendentUtilities/Code/ResplendentUtilities/Objects/RUAttributesDictionaryBuilder.m
@@ -22,6 +22,12 @@
 	[self setLineBreakMode:label.lineBreakMode];
 }
 
+-(void)absorbPropertiesFromButton:(UIButton*)button
+{
+	[self absorbPropertiesFromLabel:button.titleLabel];
+}
+
+#pragma mark - Create Attributes Dictionary
 -(NSDictionary*)createAttributesDictionary
 {
 	NSMutableDictionary* attributesDictionary = [NSMutableDictionary dictionary];


### PR DESCRIPTION
- NSString+RUTextSize method -textSizeWithBoundingWidth:attributes: now is iOS 7 only, since it uses boundingRectWithSize:options:attributes:context: which is also iOS 7 only.
- UILabel+RUTextSize now checks for textSizeWithBoundingWidth:attributes: responder.
- UILabel+RUTextSize now can absorb from a UIButton.
